### PR TITLE
add 'patch' verb to nodes resource in clusterrole to allow for node draining

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -12,6 +12,7 @@ rules:
     verbs:
       - get
       - update
+      - patch
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
When draining a node from k8s, the first step is to patch the node spec and set `node.Spec.Unschedulable=true`.  The current cluster role example doesn't include it, and it throws errors like shown in #7.  Adding this verb does indeed fix the issue.