### PR TITLE
Add sleep(120) after drain

### DIFF
--- a/docker_entrypoint.py
+++ b/docker_entrypoint.py
@@ -31,7 +31,8 @@ def main():
             result = call(kube_command)
             if result == 0:
                 print('Node Drain successful')
-                break
+                # Sleep so we do not restart before drain evicts this pod. 
+                sleep(120)
 
         else:
             if counter == 60:


### PR DESCRIPTION
Sleep for 120s after drain to prevent pod from restarting and issuing another drain before controller terminates the pod.. 